### PR TITLE
Implements `matches_schema?`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.0.3
+  - 1.0.4
 before_script:
   - mix local.hex --force
   - mix deps.get

--- a/README.md
+++ b/README.md
@@ -9,3 +9,89 @@ A library for validating JSON responses
 ## Documentation
 
 API documentation can be found at [http://hexdocs.pm/voorhees](http://hexdocs.pm/voorhees)
+
+## Examples
+
+### `Voorhees.matches_payload?`
+
+Expected payload can keys can be either strings or atoms
+
+    iex> payload = ~S[{ "foo": 1, "bar": "baz" }]
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz" })
+    true
+
+Extra key/value pairs in payload are ignored
+
+    iex> payload = ~S[{ "foo": 1, "bar": "baz", "boo": 3 }]
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz" })
+    true
+
+Extra key/value pairs in expected payload cause the validation to fail
+
+    iex> payload = ~S[{ "foo": 1, "bar": "baz"}]
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz", :boo => 3 })
+    false
+
+Validates scalar lists
+
+    iex> payload = ~S/{ "foo": 1, "bar": ["baz"]}/
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => ["baz"] })
+    true
+
+    # Order is respected
+    iex> payload = ~S/{ "foo": 1, "bar": [1, "baz"]}/
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => ["baz", 1] })
+    false
+
+Validates lists of objects
+    iex> payload = ~S/[{ "foo": 1, "bar": { "baz": 2 }}]/
+    iex> Voorhees.matches_payload?(payload, [%{ :foo => 1, "bar" => %{ "baz" => 2 } }])
+    true
+
+Validates nested objects
+    iex> payload = ~S/{ "foo": 1, "bar": { "baz": 2 }}/
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => %{ "baz" => 2 } })
+    true
+
+Validates nested lists of objects
+    iex> payload = ~S/{ "foo": 1, "bar": [{ "baz": 2 }]}/
+    iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => [%{ "baz" => 2 }] })
+    true
+
+
+### `Voorhees.matches_schema?`
+
+Validating simple objects
+
+    iex> payload = ~S[{ "foo": 1, "bar": "baz" }]
+    iex> Voorhees.matches_schema?(payload, [:foo, "bar"]) # Property names can be strings or atoms
+    true
+
+    # Extra keys
+    iex> payload = ~S[{ "foo": 1, "bar": "baz", "boo": 3 }]
+    iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
+    false
+
+    # Missing keys
+    iex> payload = ~S[{ "foo": 1 }]
+    iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
+    false
+
+Validating lists of objects
+
+    iex> payload = ~S/[{ "foo": 1, "bar": "baz" },{ "foo": 2, "bar": "baz" }]/
+    iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
+    true
+
+
+Validating nested lists of objects
+
+    iex> payload = ~S/{ "foo": 1, "bar": [{ "baz": 2 }]}/
+    iex> Voorhees.matches_schema?(payload, [:foo, bar: [:baz]])
+    true
+
+Validating that a property is a list of scalar values
+
+    iex> payload = ~S/{ "foo": 1, "bar": ["baz", 2]}/
+    iex> Voorhees.matches_schema?(payload, [:foo, bar: []])
+    true

--- a/lib/voorhees.ex
+++ b/lib/voorhees.ex
@@ -4,64 +4,163 @@ defmodule Voorhees do
   """
 
   @doc """
-
-  Returns true if the content matches the format of the expected keys matched in.
+  Returns true if the payload matches the format of the expected keys matched in.
 
   ## Examples
 
   Validating simple objects
 
-      iex> content = ~S[{ "foo": 1, "bar": "baz" }]
-      iex> Voorhees.matches_schema?(content, [:foo, "bar"]) # Property names can be strings or atoms
+      iex> payload = ~S[{ "foo": 1, "bar": "baz" }]
+      iex> Voorhees.matches_schema?(payload, [:foo, "bar"]) # Property names can be strings or atoms
       true
 
       # Extra keys
-      iex> content = ~S[{ "foo": 1, "bar": "baz", "boo": 3 }]
-      iex> Voorhees.matches_schema?(content, [:foo, "bar"])
+      iex> payload = ~S[{ "foo": 1, "bar": "baz", "boo": 3 }]
+      iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
       false
 
       # Missing keys
-      iex> content = ~S[{ "foo": 1 }]
-      iex> Voorhees.matches_schema?(content, [:foo, "bar"])
+      iex> payload = ~S[{ "foo": 1 }]
+      iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
       false
 
   Validating lists of objects
 
-      iex> content = ~S/[{ "foo": 1, "bar": "baz" },{ "foo": 2, "bar": "baz" }]/
-      iex> Voorhees.matches_schema?(content, [:foo, "bar"])
+      iex> payload = ~S/[{ "foo": 1, "bar": "baz" },{ "foo": 2, "bar": "baz" }]/
+      iex> Voorhees.matches_schema?(payload, [:foo, "bar"])
       true
 
 
   Validating nested lists of objects
 
-      iex> content = ~S/{ "foo": 1, "bar": [{ "baz": 2 }]}/
-      iex> Voorhees.matches_schema?(content, [:foo, bar: [:baz]])
+      iex> payload = ~S/{ "foo": 1, "bar": [{ "baz": 2 }]}/
+      iex> Voorhees.matches_schema?(payload, [:foo, bar: [:baz]])
       true
 
   Validating that a property is a list of scalar values
 
-      iex> content = ~S/{ "foo": 1, "bar": ["baz", 2]}/
-      iex> Voorhees.matches_schema?(content, [:foo, bar: []])
+      iex> payload = ~S/{ "foo": 1, "bar": ["baz", 2]}/
+      iex> Voorhees.matches_schema?(payload, [:foo, bar: []])
       true
 
   """
-  def matches_schema?(content, expected_keys) do
-    expected_keys = _normalize_keys(expected_keys)
-    parsed_content =  Poison.decode!(content)
+  @spec matches_schema?(String.t, list) :: boolean
+  def matches_schema?(payload, expected_keys) do
+    expected_keys = _normalize_key_list(expected_keys)
+    parsed_payload =  Poison.decode!(payload)
 
-    _matches_schema?(parsed_content, expected_keys)
+    _matches_schema?(parsed_payload, expected_keys)
   end
 
-  defp _matches_schema?(content, expected_keys) when is_list(content) do
-    content
+  @doc """
+  Returns true if the payload matches the values from expected payload.
+  Key/value pairs in the payload that are not in the expected payload are ignored.
+  Key/value pairs in the expected payload that are not in the payload cause
+  `matches_payload?` to return false
+
+  ## Examples
+
+  Expected payload can keys can be either strings or atoms
+
+      iex> payload = ~S[{ "foo": 1, "bar": "baz" }]
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz" })
+      true
+
+  Extra key/value pairs in payload are ignored
+
+      iex> payload = ~S[{ "foo": 1, "bar": "baz", "boo": 3 }]
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz" })
+      true
+
+  Extra key/value pairs in expected payload cause the validation to fail
+
+      iex> payload = ~S[{ "foo": 1, "bar": "baz"}]
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => "baz", :boo => 3 })
+      false
+
+  Validates scalar lists
+
+      iex> payload = ~S/{ "foo": 1, "bar": ["baz"]}/
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => ["baz"] })
+      true
+
+      # Order is respected
+      iex> payload = ~S/{ "foo": 1, "bar": [1, "baz"]}/
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => ["baz", 1] })
+      false
+
+  Validates lists of objects
+      iex> payload = ~S/[{ "foo": 1, "bar": { "baz": 2 }}]/
+      iex> Voorhees.matches_payload?(payload, [%{ :foo => 1, "bar" => %{ "baz" => 2 } }])
+      true
+
+  Validates nested objects
+      iex> payload = ~S/{ "foo": 1, "bar": { "baz": 2 }}/
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => %{ "baz" => 2 } })
+      true
+
+  Validates nested lists of objects
+      iex> payload = ~S/{ "foo": 1, "bar": [{ "baz": 2 }]}/
+      iex> Voorhees.matches_payload?(payload, %{ :foo => 1, "bar" => [%{ "baz" => 2 }] })
+      true
+
+  """
+  @spec matches_payload?(String.t, list | String.t) :: boolean
+  def matches_payload?(payload, expected_payload) do
+    expected_payload = _normalize_map(expected_payload)
+    parsed_payload =  Poison.decode!(payload)
+    |> _filter_out_extra_keys(expected_payload)
+
+    parsed_payload == expected_payload
+  end
+
+  defp _filter_out_extra_keys(payload, expected_payload) when is_list(payload) do
+    payload
+    |> Enum.with_index
+    |> Enum.map(fn {value, index} -> _filter_out_extra_keys(value, Enum.at(expected_payload, index)) end)
+  end
+
+  defp _filter_out_extra_keys(payload, nil) when is_map(payload), do: payload
+
+  defp _filter_out_extra_keys(payload, expected_payload) when is_map(payload) do
+    payload
+    |> Enum.filter(fn
+      {key, _value} ->
+        expected_payload
+        |> Map.keys
+        |> Enum.member?(key)
+    end)
+    |> Enum.map(fn
+      {key, value} when is_map(value) or is_list(value) -> {key, _filter_out_extra_keys(value, expected_payload[key])}
+      entry -> entry
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp _filter_out_extra_keys(payload, expected_payload), do: payload
+
+  defp _normalize_map(map) when is_map(map) do
+    map
+    |> Enum.map(&(_normalize_map_entry(&1)))
+    |> Enum.into(%{})
+  end
+
+  defp _normalize_map(list) when is_list(list), do: Enum.map(list, &(_normalize_map(&1)))
+  defp _normalize_map(value), do: value
+
+  defp _normalize_map_entry({key, value}) when is_map(value) or is_list(value), do: {_normalize_key(key), _normalize_map(value)}
+  defp _normalize_map_entry({key, value}), do: {_normalize_key(key), value}
+
+  defp _matches_schema?(payload, expected_keys) when is_list(payload) do
+    payload
     |> Enum.map(fn (element) -> _matches_schema?(element, expected_keys) end)
     |> Enum.all?
   end
 
-  defp _matches_schema?(content, expected_keys) when is_map(content) do
-    content_keys = content
+  defp _matches_schema?(payload, expected_keys) when is_map(payload) do
+    content_keys = payload
     |> Map.keys
-    |> _extract_subkeys(content)
+    |> _extract_subkeys(payload)
 
     extra_keys = content_keys -- expected_keys
     missing_keys = expected_keys -- content_keys
@@ -69,15 +168,14 @@ defmodule Voorhees do
     Enum.empty?(extra_keys) and Enum.empty?(missing_keys)
   end
 
-  defp _normalize_keys([]), do: []
-  defp _normalize_keys([key|rest]) when is_binary(key), do: [key|_normalize_keys(rest)]
-  defp _normalize_keys([key|rest]) when is_atom(key), do: [Atom.to_string(key)|_normalize_keys(rest)]
-  defp _normalize_keys([{key, subkeys}|rest]) when is_binary(key) and is_list(subkeys) do
-    [{key, _normalize_keys(subkeys)}|_normalize_keys(rest)]
+  defp _normalize_key_list([]), do: []
+  defp _normalize_key_list([{key, subkeys}|rest]) when is_list(subkeys) do
+    [{_normalize_key(key), _normalize_key_list(subkeys)}|_normalize_key_list(rest)]
   end
-  defp _normalize_keys([{key, subkeys}|rest]) when is_atom(key) and is_list(subkeys) do
-    [{Atom.to_string(key), _normalize_keys(subkeys)}|_normalize_keys(rest)]
-  end
+  defp _normalize_key_list([key|rest]), do: [_normalize_key(key)|_normalize_key_list(rest)]
+
+  defp _normalize_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp _normalize_key(key), do: key
 
   defp _extract_subkeys([], _map), do: []
   defp _extract_subkeys([key|rest], map) do

--- a/test/matches_payload_test.exs
+++ b/test/matches_payload_test.exs
@@ -1,0 +1,74 @@
+defmodule Voorhees.Test.MatchesPayload do
+  use ExUnit.Case
+  import Voorhees
+
+  test "desired keys can be either strings or atoms" do
+    content = Poison.encode! %{ a: 1, b: 2 }
+    assert matches_payload?(content, %{ :a => 1, "b" => 2 })
+  end
+
+  test "missing key from expected_payload returns false" do
+    content = Poison.encode! %{ a: 1, b: 2 }
+    assert !matches_payload?(content, %{ :a => 1, "b" => 2, :c => 3 })
+  end
+
+  test "ignores extra keys in the content passed in" do
+    content = Poison.encode! %{ a: 1, b: 2, c: 3 }
+    assert matches_payload?(content, %{ :a => 1, "b" => 2 })
+  end
+
+  test "validates scalar lists" do
+    content = Poison.encode! %{ a: 1, b: [2] }
+    assert matches_payload?(content, %{ :a => 1, "b" => [2] })
+
+    content = Poison.encode! %{ a: 1, b: [2, 1] }
+    assert !matches_payload?(content, %{ :a => 1, "b" => [2] })
+
+    content = Poison.encode! %{ a: 1, b: [2] }
+    assert !matches_payload?(content, %{ :a => 1, "b" => [1, 2] })
+  end
+
+  test "validates scalar lists with respect to array order" do
+    content = Poison.encode! %{ a: 1, b: [2, 1] }
+    assert !matches_payload?(content, %{ :a => 1, "b" => [1, 2] })
+  end
+
+  test "validates lists of objects" do
+    content = Poison.encode! [%{ a: 1, b: 2 }]
+    assert matches_payload?(content, [%{ a: 1, b: 2 }])
+
+    content = Poison.encode! [%{ a: 1, b: 2 }]
+    assert matches_payload?(content, [%{ a: 1 }])
+
+    content = Poison.encode! [%{ a: 1, b: 2 }]
+    assert !matches_payload?(content, [%{ a: 1, b: 2, c: 3 }])
+
+    content = Poison.encode! [%{ a: 1, b: 2 }]
+    assert !matches_payload?(content, [%{ a: 1, b: 2 }, %{ a: 3 }])
+
+    content = Poison.encode! [%{ a: 1, b: 2 }, %{ a: 3 }]
+    assert !matches_payload?(content, [%{ a: 1, b: 2 }])
+  end
+
+  test "validates nested objects" do
+    content = Poison.encode! %{ a: 1, b: [2], c: %{ d: 1 }  }
+    assert matches_payload?(content, %{ a: 1, b: [2], c: %{ d: 1 } })
+
+    content = Poison.encode! %{ a: 1, b: [2], c: %{ d: 1, e: 2 }  }
+    assert matches_payload?(content, %{ a: 1, b: [2], c: %{ d: 1 } })
+
+    content = Poison.encode! %{ a: 1, b: [2], c: %{ d: 1 }  }
+    assert !matches_payload?(content, %{ a: 1, b: [2], c: %{ d: 1, e: 2 } })
+  end
+
+  test "validates nested lists of objects" do
+    content = Poison.encode! %{ a: 1, b: [2], c: [%{ d: 1 }, %{ d: 2 }]  }
+    assert matches_payload?(content, %{ a: 1, b: [2], c: [%{ d: 1 }, %{ d: 2 }] })
+
+    content = Poison.encode! %{ a: 1, b: [2], c: [%{ d: 1, e: 2 }]  }
+    assert matches_payload?(content, %{ a: 1, b: [2], c: [%{ d: 1 }] })
+
+    content = Poison.encode! %{ a: 1, b: [2], c: [%{ d: 1 }]  }
+    assert !matches_payload?(content, %{ a: 1, b: [2], c: [%{ d: 1, e: 2 }] })
+  end
+end


### PR DESCRIPTION
Checks to see if payloads are equal

Handles extra key/value pairs
- Extra key/value pairs in the expected payload render the match invalid
- Extra key/value pairs in the content are ignored

Starts `matches_payload?` documentation, fixes test module name

Adds test and documentation for scalar arrays values

Adds validation of nested objects with `matches_payload?`

Refactors some of the normalization functions

Updates documentation

Handles lists of objects at the root

Validates nested lists of objects with `matches_payload`

Adds spec docs
